### PR TITLE
docker_build_with_restart does not work with scratch

### DIFF
--- a/src/checkoutservice/Dockerfile
+++ b/src/checkoutservice/Dockerfile
@@ -25,8 +25,7 @@ COPY . .
 ARG SKAFFOLD_GO_GCFLAGS
 RUN CGO_ENABLED=0 GOOS=linux go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /checkoutservice .
 
-FROM scratch
-
+FROM alpine:latest
 WORKDIR /src
 COPY --from=builder /checkoutservice /src/checkoutservice
 

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -24,7 +24,7 @@ COPY . .
 ARG SKAFFOLD_GO_GCFLAGS
 RUN CGO_ENABLED=0 GOOS=linux go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /go/bin/frontend .
 
-FROM scratch
+FROM alpine:latest
 WORKDIR /src
 COPY --from=builder /go/bin/frontend /src/server
 COPY ./templates ./templates

--- a/src/productcatalogservice/Dockerfile
+++ b/src/productcatalogservice/Dockerfile
@@ -24,8 +24,7 @@ COPY . .
 ARG SKAFFOLD_GO_GCFLAGS
 RUN CGO_ENABLED=0 GOOS=linux go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /productcatalogservice .
 
-FROM scratch
-
+FROM alpine:latest
 WORKDIR /src
 COPY --from=builder /productcatalogservice ./server
 COPY products.json .

--- a/src/shippingservice/Dockerfile
+++ b/src/shippingservice/Dockerfile
@@ -24,8 +24,7 @@ COPY . .
 ARG SKAFFOLD_GO_GCFLAGS
 RUN CGO_ENABLED=0 GOOS=linux go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /go/bin/shippingservice .
 
-FROM scratch
-
+FROM alpine:latest
 WORKDIR /src
 COPY --from=builder /go/bin/shippingservice /src/shippingservice
 ENV APP_PORT=50051


### PR DESCRIPTION
docker_build_with_restart does not work with scratch according to https://github.com/tilt-dev/tilt-extensions/issues/139.

This PR aims to change the distribution so running the demo I found in https://medium.com/@GarisSpace/run-the-online-boutique-demo-and-boost-your-microservices-skills-with-docker-desktop-and-tilt-f6732595ba18 is smooth again.